### PR TITLE
Support for boolean timestamps of badges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 
 [dependencies]
 http = "0.2.8"
+serde_json = "1.0.108"
 
 [dependencies.reqwest]
 version = "0.11.11"

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -732,6 +732,9 @@ pub struct Badge {
     /// The badge's label, shown when hovered.
     pub label: String,
     /// The badge's timestamp, if shown.
+    /// 
+    /// Why it uses `deserialize_with` attribute?
+    /// See [this issue](https://github.com/Rinrin0413/tetr-ch-rs/issues/4).
     #[serde(rename = "ts", deserialize_with = "deserialize_from_non_str_to_none")]
     pub received_at: Option<String>,
 }

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -8,7 +8,7 @@ use crate::{
         league::LeagueData,
         record::{single_play_end_ctx::SinglePlayEndCtx, EndContext, Record},
     },
-    util::{max_f64, to_unix_ts},
+    util::{deserialize_from_non_str_to_none, max_f64, to_unix_ts},
 };
 use serde::Deserialize;
 use std::fmt::{self, Display, Formatter};
@@ -732,7 +732,7 @@ pub struct Badge {
     /// The badge's label, shown when hovered.
     pub label: String,
     /// The badge's timestamp, if shown.
-    #[serde(rename = "ts")]
+    #[serde(rename = "ts", deserialize_with = "deserialize_from_non_str_to_none")]
     pub received_at: Option<String>,
 }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,6 +1,8 @@
 //! Utilities for the tetr-ch-rs.
 
 use chrono::DateTime;
+use serde::Deserialize;
+use serde_json::Value;
 
 /// Parses a RFC 3339 and ISO 8601 date to UNIX timestamp as `i64`.
 pub(crate) fn to_unix_ts(ts: &str) -> i64 {
@@ -16,6 +18,24 @@ pub(crate) fn max_f64(v1: f64, v2: f64) -> f64 {
         v2
     } else {
         v1
+    }
+}
+
+/// Deserialize from the given value to `Option<String>`.
+///
+/// If the given value is string, returns `Some(String)`.
+/// Otherwise, returns `None`.
+pub(crate) fn deserialize_from_non_str_to_none<'de, D>(
+    deserializer: D,
+) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value: Value = Deserialize::deserialize(deserializer)?;
+    if let Some(received_at) = value.as_str() {
+        Ok(Some(received_at.to_owned()))
+    } else {
+        Ok(None)
     }
 }
 


### PR DESCRIPTION
solve #4 

- 📦 Add: serde_json 
- ✨ Impl: function `deserialize_non_str_to_none` to support deserializing from `string|any` to `Option<String>`
- 🚑 Hotfix: support for boolean timestamps for badges