### PR TITLE
Missing Dedicated Response Model for `search_record` Method

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -20,6 +20,7 @@ use crate::model::{
     leaderboard::{HistoricalLeaderboardResponse, LeaderboardResponse},
     news::{NewsAllResponse, NewsLatestResponse},
     records_leaderboard::RecordsLeaderboardResponse,
+    searched_record::SearchedRecordResponse,
     searched_user::SearchedUserResponse,
     server_activity::ServerActivityResponse,
     server_stats::ServerStatsResponse,
@@ -728,7 +729,7 @@ impl Client {
         user_id: &str,
         gamemode: Gamemode,
         timestamp: i64,
-    ) -> RspErr<serde_json::Value> {
+    ) -> RspErr<SearchedRecordResponse> {
         let query_params = [
             ("user", user_id.to_string()),
             ("gamemode", gamemode.to_param()),

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -9,6 +9,7 @@ pub mod league_rank;
 pub mod news;
 pub mod records_leaderboard;
 pub mod role;
+pub mod searched_record;
 pub mod searched_user;
 pub mod server_activity;
 pub mod server_stats;

--- a/src/model/searched_record.rs
+++ b/src/model/searched_record.rs
@@ -1,0 +1,25 @@
+//! A model for the endpoint "Record Search".
+//!
+//! About the endpoint "Record Search",
+//! see the [API document](https://tetr.io/about/api/#recordsreverse).
+
+use crate::model::{
+	cache::CacheData,
+	summary::record::Record,
+};
+use serde::Deserialize;
+
+/// A struct for the response for the endpoint "Record Search".
+#[derive(Clone, Debug, Deserialize)]
+#[non_exhaustive]
+pub struct SearchedRecordResponse {
+    /// Whether the request was successful.
+    #[serde(rename = "success")]
+    pub is_success: bool,
+    /// The reason the request failed.
+    pub error: Option<String>,
+    /// Data about how this request was cached.
+    pub cache: Option<CacheData>,
+    /// The requested data.
+    pub data: Option<Record>,
+}

--- a/src/model/searched_record.rs
+++ b/src/model/searched_record.rs
@@ -3,10 +3,7 @@
 //! About the endpoint "Record Search",
 //! see the [API document](https://tetr.io/about/api/#recordsreverse).
 
-use crate::model::{
-	cache::CacheData,
-	summary::record::Record,
-};
+use crate::model::{cache::CacheData, summary::record::Record};
 use serde::Deserialize;
 
 /// A struct for the response for the endpoint "Record Search".


### PR DESCRIPTION
- 🩹 The `Client::search_record` method now has a dedicated response model (`SearchedRecordResponse`) [#71]
