### PR TITLE
`RecordsLeaderboardId::to_param` was ignoring `revolution_id` field

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -627,7 +627,7 @@ impl Client {
     ///
     /// - Upper bound is `[500000, 0, 0]`
     /// - Three entries
-    /// - Game mode: `blitz` (BLITZ)
+    /// - Game mode: `zenith` (QUICK PLAY)
     /// - Scope: `JP` (Japan)
     /// - Revolution ID: `@2024w31`
     ///
@@ -649,10 +649,10 @@ impl Client {
     ///
     /// // Get the record leaderboard.
     /// let user = client.get_records_leaderboard(
-    ///     // Record leaderboard ID: `blitz_country_JP@2024w31`
+    ///     // Record leaderboard ID: `zenith_country_JP@2024w31`
     ///     RecordsLeaderboardId::new(
-    ///         // Game mode: `blitz` (BLITZ)
-    ///         "blitz",
+    ///         // Game mode: `zenith` (QUICK PLAY)
+    ///         "zenith",
     ///         // Scope: `JP` (Japan)
     ///         Scope::Country("JP".to_string()),
     ///         // Revolution ID: `@2024w31`

--- a/src/client/param/record_leaderboard.rs
+++ b/src/client/param/record_leaderboard.rs
@@ -49,10 +49,12 @@ impl RecordsLeaderboardId {
     /// assert_eq!(id3.to_param(), "zenith_global@2024w31");
     /// ```
     pub(crate) fn to_param(&self) -> String {
-        match &self.scope {
-            Scope::Global => format!("{}_global", self.gamemode),
-            Scope::Country(c) => format!("{}_country_{}", self.gamemode, c.to_uppercase()),
-        }
+        let scope = match &self.scope {
+            Scope::Global => "global".to_string(),
+            Scope::Country(c) => format!("country_{}", c.to_uppercase()),
+        };
+        let revolution_id = self.revolution_id.as_deref().unwrap_or("");
+        format!("{}_{}{}", self.gamemode, scope, revolution_id)
     }
 }
 


### PR DESCRIPTION
- 🐛 The `RecordsLeaderboardId::to_param` method no longer ignores its `revolution_id` field [#73]
    - 📚 Improved the example code in the document of the `Client::get_records_leaderboard` method to be gettable the entries [42f3430c9cef782db6c289a7df5ebb79c77ce322]
