### PR TITLE
Conform to new error response structure

### DIFF
--- a/src/model/achievement_info.rs
+++ b/src/model/achievement_info.rs
@@ -8,6 +8,7 @@ use crate::{
     model::{
         achievement::Achievement,
         cache::CacheData,
+        error_response::ErrorResponse,
         role::Role,
         user::{UserId, UserResponse},
     },
@@ -22,7 +23,7 @@ pub struct AchievementInfoResponse {
     #[serde(rename = "success")]
     pub is_success: bool,
     /// The reason the request failed.
-    pub error: Option<String>,
+    pub error: Option<ErrorResponse>,
     /// Data about how this request was cached.
     pub cache: Option<CacheData>,
     /// The requested data.

--- a/src/model/error_response.rs
+++ b/src/model/error_response.rs
@@ -1,0 +1,19 @@
+//! A model for the error response.
+
+use serde::Deserialize;
+
+/// An error response.
+#[derive(Clone, Debug, Deserialize)]
+#[non_exhaustive]
+pub struct ErrorResponse {
+    /// The error message.
+    ///
+    /// e.g. "No such user! | Either you mistyped something, or the account no longer exists."
+    pub msg: Option<String>,
+}
+
+impl AsRef<ErrorResponse> for ErrorResponse {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}

--- a/src/model/labs/league_ranks.rs
+++ b/src/model/labs/league_ranks.rs
@@ -3,7 +3,7 @@
 //! About the endpoint "Labs League Ranks",
 //! see the [API document](https://tetr.io/about/api/#labsleagueranks).
 
-use crate::model::cache::CacheData;
+use crate::model::{cache::CacheData, error_response::ErrorResponse};
 use serde::Deserialize;
 
 /// A struct for the response for the endpoint "Labs League Ranks".
@@ -14,7 +14,7 @@ pub struct LabsLeagueRanksResponse {
     #[serde(rename = "success")]
     pub is_success: bool,
     /// The reason the request failed.
-    pub error: Option<String>,
+    pub error: Option<ErrorResponse>,
     /// Data about how this request was cached.
     pub cache: Option<CacheData>,
     /// The requested data.

--- a/src/model/labs/leagueflow.rs
+++ b/src/model/labs/leagueflow.rs
@@ -3,7 +3,7 @@
 //! About the endpoint "Labs Leagueflow",
 //! see the [API document](https://tetr.io/about/api/#labsleagueflowuser).
 
-use crate::model::cache::CacheData;
+use crate::model::{cache::CacheData, error_response::ErrorResponse};
 use serde::Deserialize;
 
 /// A struct for the response for the endpoint "Labs Leagueflow".
@@ -14,7 +14,7 @@ pub struct LabsLeagueflowResponse {
     #[serde(rename = "success")]
     pub is_success: bool,
     /// The reason the request failed.
-    pub error: Option<String>,
+    pub error: Option<ErrorResponse>,
     /// Data about how this request was cached.
     pub cache: Option<CacheData>,
     /// The requested data.

--- a/src/model/labs/scoreflow.rs
+++ b/src/model/labs/scoreflow.rs
@@ -3,7 +3,7 @@
 //! About the endpoint "Labs Scoreflow",
 //! see the [API document](https://tetr.io/about/api/#labsscoreflowusergamemode).
 
-use crate::model::cache::CacheData;
+use crate::model::{cache::CacheData, error_response::ErrorResponse};
 use serde::Deserialize;
 
 /// A struct for the response for the endpoint "Labs Scoreflow".
@@ -14,7 +14,7 @@ pub struct LabsScoreflowResponse {
     #[serde(rename = "success")]
     pub is_success: bool,
     /// The reason the request failed.
-    pub error: Option<String>,
+    pub error: Option<ErrorResponse>,
     /// Data about how this request was cached.
     pub cache: Option<CacheData>,
     /// The requested data.

--- a/src/model/leaderboard.rs
+++ b/src/model/leaderboard.rs
@@ -9,6 +9,7 @@ use crate::{
     client::{error::RspErr, param::pagination::Prisecter},
     model::{
         cache::CacheData,
+        error_response::ErrorResponse,
         league_rank::Rank,
         role::Role,
         user::{AchievementRatingCounts, UserId, UserResponse},
@@ -25,7 +26,7 @@ pub struct LeaderboardResponse {
     #[serde(rename = "success")]
     pub is_success: bool,
     /// The reason the request failed.
-    pub error: Option<String>,
+    pub error: Option<ErrorResponse>,
     /// Data about how this request was cached.
     pub cache: Option<CacheData>,
     /// The requested data.
@@ -256,7 +257,7 @@ pub struct HistoricalLeaderboardResponse {
     #[serde(rename = "success")]
     pub is_success: bool,
     /// The reason the request failed.
-    pub error: Option<String>,
+    pub error: Option<ErrorResponse>,
     /// Data about how this request was cached.
     pub cache: Option<CacheData>,
     /// The requested data.

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -3,6 +3,7 @@
 pub mod achievement;
 pub mod achievement_info;
 pub mod cache;
+pub mod error_response;
 pub mod labs;
 pub mod leaderboard;
 pub mod league_rank;

--- a/src/model/news.rs
+++ b/src/model/news.rs
@@ -9,6 +9,7 @@ use crate::{
     client::{error::RspErr, Client},
     model::{
         cache::CacheData,
+        error_response::ErrorResponse,
         league_rank::Rank,
         user::{UserId, UserResponse},
     },
@@ -24,7 +25,7 @@ pub struct NewsAllResponse {
     #[serde(rename = "success")]
     pub is_success: bool,
     /// The reason the request failed.
-    pub error: Option<String>,
+    pub error: Option<ErrorResponse>,
     /// Data about how this request was cached.
     pub cache: Option<CacheData>,
     /// The requested data.
@@ -450,7 +451,7 @@ pub struct NewsLatestResponse {
     #[serde(rename = "success")]
     pub is_success: bool,
     /// The reason the request failed.
-    pub error: Option<String>,
+    pub error: Option<ErrorResponse>,
     /// Data about how this request was cached.
     pub cache: Option<CacheData>,
     /// The requested data.

--- a/src/model/records_leaderboard.rs
+++ b/src/model/records_leaderboard.rs
@@ -3,7 +3,7 @@
 //! About the endpoint "Records Leaderboard",
 //! see the [API document](https://tetr.io/about/api/#recordsleaderboard).
 
-use crate::model::{cache::CacheData, summary::record::Record};
+use crate::model::{cache::CacheData, error_response::ErrorResponse, summary::record::Record};
 use serde::Deserialize;
 
 /// An struct for the response for the endpoint "Records Leaderboard".
@@ -14,7 +14,7 @@ pub struct RecordsLeaderboardResponse {
     #[serde(rename = "success")]
     pub is_success: bool,
     /// The reason the request failed.
-    pub error: Option<String>,
+    pub error: Option<ErrorResponse>,
     /// Data about how this request was cached.
     pub cache: Option<CacheData>,
     /// The requested data.

--- a/src/model/searched_record.rs
+++ b/src/model/searched_record.rs
@@ -3,7 +3,7 @@
 //! About the endpoint "Record Search",
 //! see the [API document](https://tetr.io/about/api/#recordsreverse).
 
-use crate::model::{cache::CacheData, summary::record::Record};
+use crate::model::{cache::CacheData, error_response::ErrorResponse, summary::record::Record};
 use serde::Deserialize;
 
 /// A struct for the response for the endpoint "Record Search".
@@ -14,7 +14,7 @@ pub struct SearchedRecordResponse {
     #[serde(rename = "success")]
     pub is_success: bool,
     /// The reason the request failed.
-    pub error: Option<String>,
+    pub error: Option<ErrorResponse>,
     /// Data about how this request was cached.
     pub cache: Option<CacheData>,
     /// The requested data.

--- a/src/model/searched_user.rs
+++ b/src/model/searched_user.rs
@@ -7,6 +7,7 @@ use crate::{
     client::{error::RspErr, Client},
     model::{
         cache::CacheData,
+        error_response::ErrorResponse,
         user::{UserId, UserResponse},
     },
 };
@@ -20,7 +21,7 @@ pub struct SearchedUserResponse {
     #[serde(rename = "success")]
     pub is_success: bool,
     /// The reason the request failed.
-    pub error: Option<String>,
+    pub error: Option<ErrorResponse>,
     /// Data about how this request was cached.
     pub cache: Option<CacheData>,
     /// The requested data.

--- a/src/model/server_activity.rs
+++ b/src/model/server_activity.rs
@@ -3,7 +3,7 @@
 //! About the endpoint "Server Activity",
 //! see the [API document](https://tetr.io/about/api/#generalactivity).
 
-use crate::model::cache::CacheData;
+use crate::model::{cache::CacheData, error_response::ErrorResponse};
 use serde::Deserialize;
 
 /// A struct for the response for the endpoint "Server Activity".
@@ -14,7 +14,7 @@ pub struct ServerActivityResponse {
     #[serde(rename = "success")]
     pub is_success: bool,
     /// The reason the request failed.
-    pub error: Option<String>,
+    pub error: Option<ErrorResponse>,
     /// Data about how this request was cached.
     pub cache: Option<CacheData>,
     /// The requested data.

--- a/src/model/server_stats.rs
+++ b/src/model/server_stats.rs
@@ -3,7 +3,7 @@
 //! About the endpoint "Server Statistics",
 //! see the [API document](https://tetr.io/about/api/#generalstats).
 
-use crate::model::cache::CacheData;
+use crate::model::{cache::CacheData, error_response::ErrorResponse};
 use serde::Deserialize;
 
 /// A struct for the response for the endpoint "Server Statistics".
@@ -14,7 +14,7 @@ pub struct ServerStatsResponse {
     #[serde(rename = "success")]
     pub is_success: bool,
     /// The reason the request failed.
-    pub error: Option<String>,
+    pub error: Option<ErrorResponse>,
     /// Data about how this request was cached.
     pub cache: Option<CacheData>,
     /// The requested data.

--- a/src/model/summary/achievements.rs
+++ b/src/model/summary/achievements.rs
@@ -3,7 +3,7 @@
 //! About the endpoint "User Summary: Achievements",
 //! see the [API document](https://tetr.io/about/api/#usersusersummariesachievements).
 
-use crate::model::{achievement::Achievement, cache::CacheData};
+use crate::model::{achievement::Achievement, cache::CacheData, error_response::ErrorResponse};
 use serde::Deserialize;
 
 /// A struct for the response for the endpoint "User Summary: Achievements".
@@ -14,7 +14,7 @@ pub struct AchievementsResponse {
     #[serde(rename = "success")]
     pub is_success: bool,
     /// The reason the request failed.
-    pub error: Option<String>,
+    pub error: Option<ErrorResponse>,
     /// Data about how this request was cached.
     pub cache: Option<CacheData>,
     /// The requested data.

--- a/src/model/summary/blitz.rs
+++ b/src/model/summary/blitz.rs
@@ -3,7 +3,7 @@
 //! About the endpoint "User Summary: BLITZ",
 //! see the [API document](https://tetr.io/about/api/#usersusersummariesblitz).
 
-use crate::model::{cache::CacheData, summary::record::Record};
+use crate::model::{cache::CacheData, error_response::ErrorResponse, summary::record::Record};
 use serde::Deserialize;
 
 /// A struct for the response for the endpoint "User Summary: BLITZ".
@@ -14,7 +14,7 @@ pub struct BlitzResponse {
     #[serde(rename = "success")]
     pub is_success: bool,
     /// The reason the request failed.
-    pub error: Option<String>,
+    pub error: Option<ErrorResponse>,
     /// Data about how this request was cached.
     pub cache: Option<CacheData>,
     /// The requested data.

--- a/src/model/summary/forty_lines.rs
+++ b/src/model/summary/forty_lines.rs
@@ -3,7 +3,7 @@
 //! About the endpoint "User Summary: 40 LINES",
 //! see the [API document](https://tetr.io/about/api/#usersusersummaries40l).
 
-use crate::model::{cache::CacheData, summary::record::Record};
+use crate::model::{cache::CacheData, error_response::ErrorResponse, summary::record::Record};
 use serde::Deserialize;
 
 /// A struct for the response for the endpoint "User Summary: 40 LINES".
@@ -14,7 +14,7 @@ pub struct FortyLinesResponse {
     #[serde(rename = "success")]
     pub is_success: bool,
     /// The reason the request failed.
-    pub error: Option<String>,
+    pub error: Option<ErrorResponse>,
     /// Data about how this request was cached.
     pub cache: Option<CacheData>,
     /// The requested data.

--- a/src/model/summary/league.rs
+++ b/src/model/summary/league.rs
@@ -3,7 +3,7 @@
 //! About the endpoint "User Summary: TETRA LEAGUE",
 //! see the [API document](https://tetr.io/about/api/#usersusersummariesleague).
 
-use crate::model::{cache::CacheData, league_rank::Rank};
+use crate::model::{cache::CacheData, error_response::ErrorResponse, league_rank::Rank};
 use serde::Deserialize;
 use std::collections::HashMap;
 
@@ -15,7 +15,7 @@ pub struct LeagueResponse {
     #[serde(rename = "success")]
     pub is_success: bool,
     /// The reason the request failed.
-    pub error: Option<String>,
+    pub error: Option<ErrorResponse>,
     /// Data about how this request was cached.
     pub cache: Option<CacheData>,
     /// The requested data.

--- a/src/model/summary/mod.rs
+++ b/src/model/summary/mod.rs
@@ -1,6 +1,6 @@
 //! Easy-to-use models of the various objects received from the User Summaries API endpoints.
 
-use crate::model::{achievement::Achievement, cache::CacheData};
+use crate::model::{achievement::Achievement, cache::CacheData, error_response::ErrorResponse};
 use serde::Deserialize;
 
 pub mod achievements;
@@ -19,7 +19,7 @@ pub struct AllSummariesResponse {
     #[serde(rename = "success")]
     pub is_success: bool,
     /// The reason the request failed.
-    pub error: Option<String>,
+    pub error: Option<ErrorResponse>,
     /// Data about how this request was cached.
     pub cache: Option<CacheData>,
     /// The requested data.

--- a/src/model/summary/zen.rs
+++ b/src/model/summary/zen.rs
@@ -3,7 +3,7 @@
 //! About the endpoint "User Summary: ZEN",
 //! see the [API document](https://tetr.io/about/api/#usersusersummarieszen).
 
-use crate::model::cache::CacheData;
+use crate::model::{cache::CacheData, error_response::ErrorResponse};
 use serde::Deserialize;
 
 /// A struct for the response for the endpoint "User Summary: ZEN".
@@ -14,7 +14,7 @@ pub struct ZenResponse {
     #[serde(rename = "success")]
     pub is_success: bool,
     /// The reason the request failed.
-    pub error: Option<String>,
+    pub error: Option<ErrorResponse>,
     /// Data about how this request was cached.
     pub cache: Option<CacheData>,
     /// The requested data.

--- a/src/model/summary/zenith.rs
+++ b/src/model/summary/zenith.rs
@@ -5,7 +5,7 @@
 //! - About the endpoint "User Summary: EXPERT QUICK PLAY",
 //! see the [API document](https://tetr.io/about/api/#usersusersummarieszenithex).
 
-use crate::model::{cache::CacheData, summary::record::Record};
+use crate::model::{cache::CacheData, error_response::ErrorResponse, summary::record::Record};
 use serde::Deserialize;
 
 /// A struct for the response for the endpoint "User Summary: QUICK PLAY".
@@ -16,7 +16,7 @@ pub struct ZenithResponse {
     #[serde(rename = "success")]
     pub is_success: bool,
     /// The reason the request failed.
-    pub error: Option<String>,
+    pub error: Option<ErrorResponse>,
     /// Data about how this request was cached.
     pub cache: Option<CacheData>,
     /// The requested data.
@@ -86,7 +86,7 @@ pub struct ZenithExResponse {
     #[serde(rename = "success")]
     pub is_success: bool,
     /// The reason the request failed.
-    pub error: Option<String>,
+    pub error: Option<ErrorResponse>,
     /// Data about how this request was cached.
     pub cache: Option<CacheData>,
     /// The requested data.

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     client::{error::RspErr, Client},
-    model::{cache::CacheData, role::Role},
+    model::{cache::CacheData, error_response::ErrorResponse, role::Role},
     util::{deserialize_from_non_str_to_none, max_f64, to_unix_ts},
 };
 use serde::Deserialize;
@@ -19,7 +19,7 @@ pub struct UserResponse {
     #[serde(rename = "success")]
     pub is_success: bool,
     /// The reason the request failed.
-    pub error: Option<String>,
+    pub error: Option<ErrorResponse>,
     /// Data about how this request was cached.
     pub cache: Option<CacheData>,
     /// The requested data.

--- a/src/model/user_records.rs
+++ b/src/model/user_records.rs
@@ -3,7 +3,7 @@
 //! About the endpoint "User Personal Records",
 //! see the [API document](https://tetr.io/about/api/#usersuserrecordsgamemodeleaderboard).
 
-use crate::model::{cache::CacheData, summary::record::Record};
+use crate::model::{cache::CacheData, error_response::ErrorResponse, summary::record::Record};
 use serde::Deserialize;
 
 /// A struct for the response for the endpoint "User Personal Records".
@@ -14,7 +14,7 @@ pub struct UserRecordsResponse {
     #[serde(rename = "success")]
     pub is_success: bool,
     /// The reason the request failed.
-    pub error: Option<String>,
+    pub error: Option<ErrorResponse>,
     /// Data about how this request was cached.
     pub cache: Option<CacheData>,
     /// The requested data.


### PR DESCRIPTION
- 🛠️ Replaced the `String` types with `ErrorResponse` model in all the response models [#84]
    - ✨ Implemented `ErrorResponse` model [8c9534c094c2ec7d3b3df98da7a484ccc2639e41]
