### PR TITLE
Remove unnecessary `dbg` macro call in `Client::get_user` method

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -178,7 +178,6 @@ impl Client {
     /// # }
     /// ```
     pub async fn get_user(&self, user: &str) -> RspErr<UserResponse> {
-        dbg!(encode(user.to_lowercase()));
         let url = format!("{}users/{}", API_URL, encode(user.to_lowercase()));
         let res = self.client.get(url).send().await;
         response(res).await


### PR DESCRIPTION
- ⚰️ Removed an unnecessary `dbg` macro call in the `Client::get_user` method implementation [#104]
